### PR TITLE
Fix: history.pushState requires same-origin

### DIFF
--- a/src/views/Pages/Login/Login.js
+++ b/src/views/Pages/Login/Login.js
@@ -37,6 +37,7 @@ function removeParam(parameter) {
             url = urlBase + '?' + pars.join('&');
         else
             url = urlBase;
+        url = url.replace(window.location.origin, ''); // history.pushState requires same-origin
         window.history.pushState('', document.title, url); // added this line to push the new url directly to url bar .
 
     }


### PR DESCRIPTION
This should fix https://github.com/rclone/rclone-webui-react/issues/27

According to https://developer.mozilla.org/en-US/docs/Web/API/History/pushState, history object only accepts same-origin changes. However, Chrome does not seem to recongise "<origin>/" and "<origin>" as the same-origin urls. That's the reason why we are seeing exceptions.

This should be regarded as a temporary fix if #30 is going to be implemented.